### PR TITLE
Adding transformations for io.debezium.time.Date Ignore vscode files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ target/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+#VS Code cache files
+
+.settings/
+.classpath
+.project

--- a/CustomJdbcDialog/src/main/java/com/purbon/kafka/connect/jdbc/CustomMySqlJdbcDialect.java
+++ b/CustomJdbcDialog/src/main/java/com/purbon/kafka/connect/jdbc/CustomMySqlJdbcDialect.java
@@ -10,12 +10,15 @@ import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.stream.Collectors;
 
 public class CustomMySqlJdbcDialect extends MySqlDatabaseDialect {
@@ -42,6 +45,13 @@ public class CustomMySqlJdbcDialect extends MySqlDatabaseDialect {
     protected boolean maybeBindLogical(PreparedStatement statement, int index, Schema schema, Object value) throws SQLException {
         if (schema.name() != null) {
             switch (schema.name()) {
+                case DebeziumTimeUnits.DATE_TIMESTAMP:
+                    Calendar calendar = new GregorianCalendar(1970, Calendar.JANUARY, 1, 0, 0, 0);      
+                    calendar.add(Calendar.DAY_OF_YEAR, (int)value);
+                    Date date = new Date(calendar.getTimeInMillis());
+                    log.debug("TimeConversion[" + DebeziumTimeUnits.DATE_TIMESTAMP + "] value=" + value + " into time="+date.toString());               
+                    statement.setDate(index, date);
+                    return true;
                 case DebeziumTimeUnits.MILLIS_TIMESTAMP:
                     Timestamp millisTimestamp = Conversions.toTimestampFromMillis((long)value);
                     log.debug("TimeConversion[io.debezium.time.Timestamp]: value="+value+" into time="+millisTimestamp);

--- a/CustomJdbcDialog/src/main/java/com/purbon/kafka/connect/jdbc/CustomSqlServerJdbcDialect.java
+++ b/CustomJdbcDialog/src/main/java/com/purbon/kafka/connect/jdbc/CustomSqlServerJdbcDialect.java
@@ -81,6 +81,19 @@ public class CustomSqlServerJdbcDialect extends SqlServerDatabaseDialect {
             return null;
         }
 
+        if(schema.name() != null){
+            switch(schema.name()){
+                case DebeziumTimeUnits.DATE_TIMESTAMP:
+                    return Types.DATE;
+                case DebeziumTimeUnits.MILLIS_TIMESTAMP:
+                    return Types.NVARCHAR;
+                case DebeziumTimeUnits.NANOS_TIMESTAMP:
+                    return Types.TIMESTAMP;
+                default:
+                    // pass
+            }
+        }
+
         switch (schema.type()) {
             case INT8:
             case INT16:

--- a/CustomJdbcDialog/src/main/java/com/purbon/kafka/connect/jdbc/CustomSqlServerJdbcDialect.java
+++ b/CustomJdbcDialog/src/main/java/com/purbon/kafka/connect/jdbc/CustomSqlServerJdbcDialect.java
@@ -10,12 +10,15 @@ import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 public class CustomSqlServerJdbcDialect extends SqlServerDatabaseDialect {
@@ -47,6 +50,13 @@ public class CustomSqlServerJdbcDialect extends SqlServerDatabaseDialect {
     protected boolean maybeBindLogical(PreparedStatement statement, int index, Schema schema, Object value) throws SQLException {
         if (schema.name() != null) {
             switch (schema.name()) {
+                case DebeziumTimeUnits.DATE_TIMESTAMP:
+                    Calendar calendar = new GregorianCalendar(1970, Calendar.JANUARY, 1, 0, 0, 0);      
+                    calendar.add(Calendar.DAY_OF_YEAR, (int)value);
+                    Date date = new Date(calendar.getTimeInMillis());
+                    log.debug("TimeConversion[" + DebeziumTimeUnits.DATE_TIMESTAMP + "] value=" + value + " into time="+date.toString());               
+                    statement.setDate(index, date);
+                    return true;
                 case DebeziumTimeUnits.MILLIS_TIMESTAMP:
                     Timestamp millisTimestamp = Conversions.toTimestampFromMillis((long)value);
                     log.debug("TimeConversion[io.debezium.time.Timestamp]: value="+value+" into time="+millisTimestamp.toString());
@@ -96,6 +106,8 @@ public class CustomSqlServerJdbcDialect extends SqlServerDatabaseDialect {
     protected String getSqlType(SinkRecordField field) {
         if (field.schemaName() != null) {
             switch (field.schemaName()) {
+                case DebeziumTimeUnits.DATE_TIMESTAMP:
+                    return "date";
                 case DebeziumTimeUnits.MILLIS_TIMESTAMP:
                     return "datetime";
                 case DebeziumTimeUnits.NANOS_TIMESTAMP:

--- a/CustomJdbcDialog/src/main/java/com/purbon/kafka/connect/jdbc/DebeziumTimeUnits.java
+++ b/CustomJdbcDialog/src/main/java/com/purbon/kafka/connect/jdbc/DebeziumTimeUnits.java
@@ -2,6 +2,7 @@ package com.purbon.kafka.connect.jdbc;
 
 public class DebeziumTimeUnits {
 
+    public static final String DATE_TIMESTAMP = "io.debezium.time.Date";
     public static final String MILLIS_TIMESTAMP = "io.debezium.time.Timestamp";
     public static final String NANOS_TIMESTAMP = "io.debezium.time.NanoTimestamp";
 }


### PR DESCRIPTION
Adding support for "date" type, which comes as an int (by debezium), and SQL Server sink connector getting an error from SQL server:
`Operand type clash: int is incompatible with date`